### PR TITLE
Fix: enable CLI env via Dotenv bootstrap and dev .env defaults

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+APP_ENV=dev
+APP_DEBUG=1
+APP_SECRET=dev_not_secret_change_locally
+
+DATABASE_URL="mysql://app:app@127.0.0.1:3307/app?serverVersion=8.4&charset=utf8mb4"
+
+REDIS_DSN=redis://127.0.0.1:6379
+MAILER_DSN=smtp://127.0.0.1:8025

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,19 @@
 /vendor/
 var/
 /node_modules/
-/.env.local
-/.env
+
+# Local overrides
+.env.local
 .env.*.local
 .env.local.php
 .phpunit.result.cache
+
 /build/
 .env.test
 .env.*.backup
 .env.*.override
 .env.*.secrets
+
+# Our examples in env/ are tracked; the real ones are ignored
 env/.env.dev
 env/.env.prod

--- a/README.md
+++ b/README.md
@@ -31,3 +31,22 @@ Provide DB creds and secure `APP_SECRET`.
 - Symfony 7 skeleton + ORM pack
 - composer.lock is tracked for deterministic installs
 - No secrets committed; use env files per environment
+
+## CLI & Environment Variables
+- The project includes a committed `.env` with safe dev defaults so `php bin/console` works locally.
+- For overrides, create `.env.local` (gitignored).
+- In Docker, environment variables come from docker-compose. To run CLI inside container:
+
+  ```bash
+  make bash
+  php bin/console about
+  ```
+
+## First run
+```bash
+cp env/.env.dev.example env/.env.dev
+make up
+make install
+php bin/console about
+open http://localhost:8080/health
+```

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -3,8 +3,9 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (!class_exists(Dotenv::class)) {
-    throw new RuntimeException('Please run "composer install".');
+if (!isset($_SERVER['APP_ENV'])) {
+    if (class_exists(Dotenv::class)) {
+        (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+    }
 }
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');


### PR DESCRIPTION
## Summary
- load environment variables via Dotenv during bootstrap
- commit safe development `.env` and stop ignoring it
- document CLI usage and first-run instructions

## Testing
- `php -r 'echo file_exists("config/bootstrap.php") ? "bootstrap:ok" : "bootstrap:missing", PHP_EOL;'`
- `php -r 'echo file_exists(".env") ? ".env:present" : ".env:missing", PHP_EOL;'`
- `php bin/console about`


------
https://chatgpt.com/codex/tasks/task_e_68a3833f2ab08324adff6db5482b1108