### PR TITLE
Ensure controllers are tagged for argument autowiring

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,11 @@ services:
     App\:
         resource: '../src/'
         exclude:
+            - '../src/Controller/'
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
+
+    App\Controller\:
+        resource: '../src/Controller/'
+        tags: ['controller.service_arguments']


### PR DESCRIPTION
## Summary
- tag controllers with `controller.service_arguments`

## Testing
- `vendor/bin/phpstan analyse -c phpstan.neon --no-progress`
- `vendor/bin/psalm --no-cache`
- `vendor/bin/php-cs-fixer fix --dry-run --diff`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2934c4c8324bdedf46b45c7aa63