### PR TITLE
Dev env fix: docker-compose env_file + aligned DATABASE_URL; added env examples and local run guide

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,9 @@
 APP_ENV=dev
 APP_DEBUG=1
-APP_SECRET=dev_not_secret_change_locally
+APP_SECRET=dev-secret-key-change-me
 
+# Host CLI connects to Docker MySQL via published port
 DATABASE_URL="mysql://app:app@127.0.0.1:3307/app?serverVersion=8.4&charset=utf8mb4"
 
-REDIS_DSN=redis://127.0.0.1:6379
-MAILER_DSN=smtp://127.0.0.1:8025
+MAILER_DSN=smtp://127.0.0.1:1025
+REDIS_URL=redis://127.0.0.1:6379

--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
 # Boilerplate App (Symfony 7 + Docker)
 
-## Quickstart (Dev)
-0. Pull latest code
-1. Copy env: `cp env/.env.dev.example env/.env.dev`
-2. Start stack: `make up`
-3. Install deps: `make install`
-4. Check health: `make health` (or visit http://localhost:8080/health)
+## Run Locally (Dev)
+
+1) Copy envs (creates an untracked env for docker):
+   cp env/.env.dev.example env/.env.dev
+
+2) Start stack:
+   make up
+   # first run: MySQL may take ~10–20s to initialize
+
+3) Install PHP deps inside the php container:
+   make install
+
+4) Check health:
+   open http://localhost:8080/health
+   # expect: {"status":"ok","env":"dev","db":true}
+
+### Tips
+- If you see docker warnings about MYSQL_* being unset, ensure `compose/docker-compose.dev.yml`
+  has `env_file: ../env/.env.dev` under both `php` and `db` services.
+- If `db:false` persists:
+  - Recreate with a clean volume so MySQL initializes with the new creds:
+    docker compose -f compose/docker-compose.dev.yml down -v
+    docker compose -f compose/docker-compose.dev.yml up -d
+  - Watch DB logs:
+    docker compose -f compose/docker-compose.dev.yml logs -f db
 
 Services:
 - App: http://localhost:8080
@@ -42,11 +61,3 @@ Provide DB creds and secure `APP_SECRET`.
   php bin/console about
   ```
 
-## First run
-```bash
-cp env/.env.dev.example env/.env.dev
-make up
-make install
-php bin/console about
-open http://localhost:8080/health
-```

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -25,11 +25,8 @@ services:
 
   db:
     image: mysql:8.4
-    environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    env_file:
+      - ../env/.env.dev
     volumes:
       - db_data:/var/lib/mysql
       - ../docker/db/init:/docker-entrypoint-initdb.d

--- a/env/.env.dev.example
+++ b/env/.env.dev.example
@@ -1,5 +1,14 @@
+APP_ENV=dev
+APP_DEBUG=1
+APP_SECRET=replace-me-dev
+
+# MySQL used by containers (php ↔ db via service name)
 MYSQL_DATABASE=app
 MYSQL_USER=app
 MYSQL_PASSWORD=app
 MYSQL_ROOT_PASSWORD=root
-DATABASE_URL="mysql://app:app@db:3306/app"
+DATABASE_URL="mysql://app:app@db:3306/app?serverVersion=8.4&charset=utf8mb4"
+
+# Mailpit & Redis (container names)
+MAILER_DSN=smtp://mailpit:1025
+REDIS_URL=redis://redis:6379


### PR DESCRIPTION
## Summary
- align dev env vars and service name across docker-compose and env examples
- add canonical .env.dev.example and host-ready .env
- document local run steps and troubleshooting tips

## Testing
- `test -f env/.env.dev.example && echo "dev.example: OK" || echo "dev.example: MISSING"`
- `test -f env/.env.dev && echo "dev: OK" || echo "dev: MISSING"`
- `grep -E '^DATABASE_URL=' .env && echo "root .env: has DATABASE_URL"`
- `docker compose -f compose/docker-compose.dev.yml config >/dev/null && echo "compose config: OK" || true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4afef6ea88324a7563266969fa7de