### PR TITLE
feat(dev): add Adminer DB UI on http://localhost:8081 and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,10 @@ psalm:
 
 cs-fix:
 	$(COMPOSE_DEV) exec php vendor/bin/php-cs-fixer fix --dry-run --diff
+
+adminer:
+	$(COMPOSE_DEV) up -d adminer
+	@echo "Open: http://localhost:8081"
+
+down-adminer:
+	$(COMPOSE_DEV) stop adminer

--- a/README.md
+++ b/README.md
@@ -114,3 +114,22 @@ What it does:
   php bin/console make:migration
   php bin/console doctrine:migrations:migrate
   ```
+
+## Database UI (Adminer)
+
+- URL: http://localhost:8081
+- Server: db        (inside Docker)
+- Username: app
+- Password: app
+- Database: app
+
+If you connect from a host DB client (Sequel Ace, TablePlus, DBeaver):
+- Host: 127.0.0.1
+- Port: 3307
+- Username: app
+- Password: app
+- Database: app
+
+> Prefer a native client? Try:
+> - macOS: Sequel Ace (free), TablePlus (paid)
+> - Cross‑platform: DBeaver (free), DataGrip (paid)

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -41,5 +41,17 @@ services:
     ports:
       - "8025:8025"
 
+  adminer:
+    image: adminer:latest
+    depends_on:
+      - db
+    environment:
+      # optional: set a theme, e.g. "pepa-linha"
+      # ADMINER_DESIGN: pepa-linha
+      # ADMINER_DEFAULT_SERVER lets Adminer prefill the server host
+      ADMINER_DEFAULT_SERVER: db
+    ports:
+      - "8081:8080"
+
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- expose Adminer service in dev compose for quick DB browsing
- document connection details for Adminer and host clients
- add Makefile helpers to start and stop Adminer

## Testing
- `make stan` *(fails: docker not installed)*
- `make psalm` *(fails: docker not installed)*
- `make cs-fix` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c36e128c8324aa66bbc7a648d257