### PR TITLE
feat(dev): HTTPS custom domain via mkcert; compose mounts certs; deploy.sh supports --domain-base, hosts updates, and prints URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,28 @@ If you connect from a host DB client (Sequel Ace, TablePlus, DBeaver):
 > Prefer a native client? Try:
 > - macOS: Sequel Ace (free), TablePlus (paid)
 > - Cross‑platform: DBeaver (free), DataGrip (paid)
+
+## Custom HTTPS dev domain
+
+We use [mkcert](https://github.com/FiloSottile/mkcert) to generate a local CA and TLS certs for a wildcard domain.
+
+### One-time setup (macOS)
+```bash
+brew install mkcert nss   # nss needed by Firefox
+```
+
+Use a custom domain base
+
+deploy.sh can provision certs and /etc/hosts entries:
+
+```bash
+./deploy.sh dev --domain-base dev.local.test
+# adds:
+# - TLS certs under tls/dev.local.test/
+# - 127.0.0.1 app.dev.local.test (and adminer/mail convenience hosts)
+# App available at: https://app.dev.local.test
+```
+
+Change later: just re-run with a new --domain-base new.local.test.
+
+Adminer and Mailpit stay on localhost:8081 / 8025 by default. You can optionally reverse-proxy them via Nginx in a future iteration.

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -18,8 +18,10 @@ services:
       dockerfile: docker/nginx/Dockerfile
     volumes:
       - ../:/var/www/app
+      - ../tls/${DOMAIN_BASE:-dev.local.test}:/etc/nginx/certs:ro
     ports:
-      - "8080:80"
+      - "443:443"
+      - "8080:80"   # optional: keep http for quick checks
     depends_on:
       - php
 

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,6 +1,24 @@
+# HTTP -> redirect to HTTPS
 server {
   listen 80;
   server_name _;
+  return 301 https://$host$request_uri;
+}
+
+# HTTPS app
+server {
+  listen 443 ssl http2;
+  server_name _;
+
+  ssl_certificate     /etc/nginx/certs/fullchain.pem;
+  ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+  # recommended basics
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:10m;
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_prefer_server_ciphers on;
+
   root /var/www/app/public;
 
   location / {

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN_BASE="${1:-dev.local.test}"
+OUT_DIR="tls/${DOMAIN_BASE}"
+mkdir -p "$OUT_DIR"
+
+# Check mkcert
+if ! command -v mkcert >/dev/null 2>&1; then
+  echo "[error] mkcert not found. On macOS: brew install mkcert nss"
+  exit 2
+fi
+
+# Install local CA (idempotent)
+mkcert -install
+
+# Wildcard + root cert
+echo "[info] Generating certs for *.${DOMAIN_BASE} and ${DOMAIN_BASE}"
+mkcert -cert-file "${OUT_DIR}/fullchain.pem" -key-file "${OUT_DIR}/privkey.pem" "*.${DOMAIN_BASE}" "${DOMAIN_BASE}"
+
+echo "[success] Certs created at ${OUT_DIR}"


### PR DESCRIPTION
## Summary
- add TLS setup script using mkcert for wildcard domains
- serve app over HTTPS with Nginx and redirect HTTP traffic
- mount certificates in dev compose stack and expose port 443
- extend deploy.sh to configure domain base, generate certs, manage /etc/hosts entries, and print environment URLs
- document custom HTTPS dev domain workflow in README

## Testing
- `bash -n scripts/setup-tls.sh`
- `bash -n deploy.sh`
- `docker compose -f compose/docker-compose.dev.yml config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4c9c20e40832490a4157b63b12d6e